### PR TITLE
new: Update rules to use `package.json` in cwd instead of root.

### DIFF
--- a/packages/dev/src/helpers.ts
+++ b/packages/dev/src/helpers.ts
@@ -88,6 +88,17 @@ export function getTargetNodeRuntime(): number {
 	return nodeVersion;
 }
 
+export function getParentNodeRuntime(): number {
+	const pkg = getClosestPackageJson(process.cwd());
+	const version = pkg.engines?.node;
+
+	if (version) {
+		return parseVersion(version);
+	}
+
+	return getTargetNodeRuntime();
+}
+
 // PACKAGES
 
 export function getPackageVersion(pkgName: string): number {

--- a/packages/eslint-config/src/base.ts
+++ b/packages/eslint-config/src/base.ts
@@ -1,7 +1,7 @@
 import type eslint from 'eslint';
-import { CASE_SENSITIVE, getTargetNodeRuntime } from '@moonrepo/dev';
+import { CASE_SENSITIVE, getParentNodeRuntime } from '@moonrepo/dev';
 
-const nodeVersion = getTargetNodeRuntime();
+const nodeVersion = getParentNodeRuntime();
 
 // The following rules are either overriding Airbnb's defaults,
 // or they are enabling new rules that aren't in Airbnb yet.

--- a/packages/eslint-config/src/node.ts
+++ b/packages/eslint-config/src/node.ts
@@ -1,7 +1,7 @@
 import type eslint from 'eslint';
-import { getTargetNodeRuntime } from '@moonrepo/dev';
+import { getParentNodeRuntime } from '@moonrepo/dev';
 
-const nodeVersion = getTargetNodeRuntime();
+const nodeVersion = getParentNodeRuntime();
 
 const config: eslint.Linter.Config = {
 	plugins: ['node', 'compat'],

--- a/packages/eslint-config/src/unicorn.ts
+++ b/packages/eslint-config/src/unicorn.ts
@@ -1,7 +1,7 @@
 import type eslint from 'eslint';
-import { CONFIGS_LIST, getTargetNodeRuntime } from '@moonrepo/dev';
+import { CONFIGS_LIST, getParentNodeRuntime } from '@moonrepo/dev';
 
-const nodeVersion = getTargetNodeRuntime();
+const nodeVersion = getParentNodeRuntime();
 
 const config: eslint.Linter.Config = {
 	plugins: ['unicorn'],


### PR DESCRIPTION
This will resolve the correct `engines` field.